### PR TITLE
Added datatype and annotations property to PropertyDocumentation class

### DIFF
--- a/SharpTiles/org.SharpTiles.Documentation.Test/PropertyDocumentationTest.cs
+++ b/SharpTiles/org.SharpTiles.Documentation.Test/PropertyDocumentationTest.cs
@@ -2,23 +2,25 @@
  * SharpTiles, R.Z. Slijp(2008), www.sharptiles.org
  *
  * This file is part of SharpTiles.
- * 
+ *
  * SharpTiles is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SharpTiles is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with SharpTiles.  If not, see <http://www.gnu.org/licenses/>.
  */
  using NUnit.Framework;
 using NUnit.Framework.SyntaxHelpers;
-using org.SharpTiles.Tags.CoreTags;
+ using org.SharpTiles.Common;
+ using org.SharpTiles.Tags;
+ using org.SharpTiles.Tags.CoreTags;
  using org.SharpTiles.Tags.FormatTags;
 
 namespace org.SharpTiles.Documentation.Test
@@ -41,5 +43,71 @@ namespace org.SharpTiles.Documentation.Test
             var doc = new PropertyDocumentation(new ResourceKeyStack(bundle), typeof (Set).GetProperty("Var"));
             Assert.That(doc.Required, Is.True);
         }
+
+        [Test]
+        public void PropertyWithoutDataTypePropertyAttributeShouldSetTextDataType()
+        {
+            var doc = new PropertyDocumentation(new ResourceKeyStack(bundle), typeof (Set).GetProperty("Var"));
+            Assert.That(doc.DataType, Is.EqualTo(TagAttributeDataType.Text));
+        }
+
+        [Test]
+        public void PropertyWithNumberPropertyAttributeShouldSetNumberDataType()
+        {
+            var doc = new PropertyDocumentation(new ResourceKeyStack(bundle), typeof (TestTag).GetProperty("Id"));
+            Assert.That(doc.DataType, Is.EqualTo(TagAttributeDataType.Number));
+        }
+
+        [Test]
+        public void PropertyWithBooleanPropertyAttributeShouldSetBooleanDataType()
+        {
+            var doc = new PropertyDocumentation(new ResourceKeyStack(bundle), typeof (TestTag).GetProperty("Visible"));
+            Assert.That(doc.DataType, Is.EqualTo(TagAttributeDataType.Boolean));
+        }
+
+        [Test]
+        public void PropertyWithEnumPropertyAttributeShouldSetEnumDataType()
+        {
+            var doc = new PropertyDocumentation(new ResourceKeyStack(bundle), typeof (TestTag).GetProperty("Color"));
+            Assert.That(doc.DataType, Is.EqualTo(TagAttributeDataType.Enum));
+        }
+
+        [Test]
+        public void PropertyWithPropertyAnnotationAttributesShouldSetAnnotations()
+        {
+            var doc = new PropertyDocumentation(new ResourceKeyStack(bundle), typeof (TestTag).GetProperty("Color"));
+            Assert.That(doc.Annotations.Length, Is.EqualTo(2));
+            Assert.That(doc.Annotations[0], Is.EqualTo("test1"));
+            Assert.That(doc.Annotations[1], Is.EqualTo("test2"));
+        }
+
+    }
+
+    internal enum TestEnum
+    {
+        Black,
+        White
+    }
+    internal class TestTag : ITag
+    {
+        public ParseContext Context { get; set; }
+        public string TagName => "test-tag";
+        public ITagGroup Group { get; set; }
+        [NumberPropertyType]
+        public ITagAttribute Id { get; set; }
+        [BooleanPropertyType]
+        public ITagAttribute Visible { get; set; }
+        [EnumProperyType(typeof(TestEnum))]
+        [PropertyAnnotation("test1")]
+        [PropertyAnnotation("test2")]
+        public ITagAttribute Color { get; set; }
+        public TagState State { get; set; }
+        public TagBodyMode TagBodyMode { get; }
+        public string Evaluate(TagModel model)
+        {
+            return string.Empty;
+        }
+
+        public ITagAttributeSetter AttributeSetter { get; }
     }
 }

--- a/SharpTiles/org.SharpTiles.Documentation/PropertyDocumentation.cs
+++ b/SharpTiles/org.SharpTiles.Documentation/PropertyDocumentation.cs
@@ -2,17 +2,17 @@
  * SharpTiles, R.Z. Slijp(2008), www.sharptiles.org
  *
  * This file is part of SharpTiles.
- * 
+ *
  * SharpTiles is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SharpTiles is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with SharpTiles.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -26,6 +26,15 @@ using org.SharpTiles.Tags.DefaultPropertyValues;
 
 namespace org.SharpTiles.Documentation
 {
+    [DataContract]
+    public enum TagAttributeDataType
+    {
+        Text,
+        Number,
+        Boolean,
+        Enum
+    }
+
     [DataContract]
     public class PropertyDocumentation : IDescriptionElement
     {
@@ -45,6 +54,36 @@ namespace org.SharpTiles.Documentation
             DetermineDefault(property);
             _description = DescriptionAttribute.Harvest(property)??_messagePath.Description;
             _enumValues = GetEnumValues(_property.GetCustomAttribute<EnumProperyTypeAttribute>(false)?.EnumType);
+            DataType = DetermineDataType(_property);
+            Annotations = GetAnnotations(_property);
+        }
+
+        private string[] GetAnnotations(PropertyInfo property)
+        {
+            return property.GetCustomAttributes<PropertyAnnotationAttribute>().Select(a => a.Annotation).ToArray();
+        }
+
+        [DataMember]
+        public TagAttributeDataType DataType { get; }
+
+        [DataMember]
+        public string[] Annotations { get; }
+
+        private TagAttributeDataType DetermineDataType(PropertyInfo property)
+        {
+            if (property.GetCustomAttribute<EnumProperyTypeAttribute>() != null)
+            {
+                return TagAttributeDataType.Enum;
+            }
+            if (property.GetCustomAttribute<NumberPropertyTypeAttribute>() != null)
+            {
+                return TagAttributeDataType.Number;
+            }
+            if (property.GetCustomAttribute<BooleanPropertyTypeAttribute>() != null)
+            {
+                return TagAttributeDataType.Boolean;
+            }
+            return TagAttributeDataType.Text;
         }
 
         public PropertyDocumentation(ResourceKeyStack messagePath, PropertyAttribute property)
@@ -99,7 +138,7 @@ namespace org.SharpTiles.Documentation
 
         private void DetermineDefault(PropertyInfo property)
         {
-            var fallBack = (IDefaultPropertyValue)property.GetCustomAttributes(typeof(IDefaultPropertyValue), false).FirstOrDefault(); 
+            var fallBack = (IDefaultPropertyValue)property.GetCustomAttributes(typeof(IDefaultPropertyValue), false).FirstOrDefault();
             if(fallBack!=null)
             {
                 _default = fallBack.ToString();
@@ -112,7 +151,7 @@ namespace org.SharpTiles.Documentation
 
         private EnumValue[] GetEnumValues(Type enumType)
         {
-            
+
             return enumType != null ? Enum.GetValues(enumType)
                 .Cast<object>()
                 .Select(v => EnumValue.Create(enumType, v))

--- a/SharpTiles/org.SharpTiles.TagLib/PropertyAnnotationAttribute.cs
+++ b/SharpTiles/org.SharpTiles.TagLib/PropertyAnnotationAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace org.SharpTiles.Tags
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
+    public class PropertyAnnotationAttribute:Attribute
+    {
+        public string Annotation { get; }
+
+        public PropertyAnnotationAttribute(string annotation)
+        {
+            Annotation = annotation;
+        }
+    }
+}

--- a/SharpTiles/org.SharpTiles.TagLib/org.SharpTiles.Tags.csproj
+++ b/SharpTiles/org.SharpTiles.TagLib/org.SharpTiles.Tags.csproj
@@ -93,6 +93,7 @@
     <Compile Include="ITagLib.cs" />
     <Compile Include="ITagExtendTagLib.cs" />
     <Compile Include="NumberPropertyTypeAttribute.cs" />
+    <Compile Include="PropertyAnnotationAttribute.cs" />
     <Compile Include="ReflectionAttributeSetter.cs" />
     <Compile Include="RequiredAttribute.cs" />
     <Compile Include="CoreTags\BaseCoreTag.cs" />


### PR DESCRIPTION
I changed the property documentor to add a DataType property which is an Enum: Text, Boolean, Number or Enum. The value is determined by the existence of either a NumberProperty, BooleanProperty or EnumProperty attribute. If these don't exist it default to Text.

Furthermore I added the PropertyAnnotationAttribute with which arbitrary string based annotations can be added to a property, useful for project specific processing.