### PR TITLE
Documentor now stores all TagDocumentation instances in a dictionary …

### DIFF
--- a/SharpTiles/org.SharpTiles.Documentation.Test/DocumentModelTest.cs
+++ b/SharpTiles/org.SharpTiles.Documentation.Test/DocumentModelTest.cs
@@ -2,17 +2,17 @@
  * SharpTiles, R.Z. Slijp(2008), www.sharptiles.org
  *
  * This file is part of SharpTiles.
- * 
+ *
  * SharpTiles is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SharpTiles is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with SharpTiles.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -46,7 +46,8 @@ namespace org.SharpTiles.Documentation.Test
         [Test]
         public void PropertyInTagsShouldBePresent()
         {
-            var tag = new TagDocumentation(new ResourceKeyStack(bundle), new Out(), new List<Func<ITag, TagDocumentation, bool>>());
+            var tagDict = new Dictionary<int,TagDocumentation>();
+            var tag = new TagDocumentation(new ResourceKeyStack(bundle), new Out(), new List<Func<ITag, TagDocumentation, bool>>(),tagDict);
             Assert.That(tag.Name, Is.EqualTo(new Out().TagName));
             Assert.That(tag.Properties, Is.Not.Null);
             Assert.That(tag.Properties.Count, Is.GreaterThan(0));
@@ -80,7 +81,7 @@ namespace org.SharpTiles.Documentation.Test
             var key = new ResourceKeyStack(bundle);
             key = key.BranchFor(new Format());
             key = key.BranchFor(new Message());
-            
+
             var property = new PropertyDocumentation(key,
                                                      typeof(Message).GetProperty("Scope"));
             Assert.That(property.DescriptionKey, Is.EqualTo("description_BaseCoreTagWithOptionalVariable_Scope"));
@@ -89,8 +90,8 @@ namespace org.SharpTiles.Documentation.Test
         [Test]
         public void TagGroupShouldReturnDescriptionKey()
         {
-            
-            var taggroup = new TagGroupDocumentation(new ResourceKeyStack(bundle), new Core(), new List<Func<ITag, TagDocumentation, bool>>());
+            var tagDict = new Dictionary<int,TagDocumentation>();
+            var taggroup = new TagGroupDocumentation(new ResourceKeyStack(bundle), new Core(), new List<Func<ITag, TagDocumentation, bool>>(),tagDict);
             Assert.That(taggroup.DescriptionKey, Is.EqualTo("description_Core"));
         }
 
@@ -105,7 +106,8 @@ namespace org.SharpTiles.Documentation.Test
         [Test]
         public void TagInTagGroupsShouldBePresent()
         {
-            var taggroup = new TagGroupDocumentation(new ResourceKeyStack(bundle), new Core(), new List<Func<ITag, TagDocumentation, bool>>());
+            var tagDict = new Dictionary<int,TagDocumentation>();
+            var taggroup = new TagGroupDocumentation(new ResourceKeyStack(bundle), new Core(), new List<Func<ITag, TagDocumentation, bool>>(),tagDict);
             Assert.That(taggroup.Name, Is.EqualTo(new Core().Name));
             Assert.That(taggroup.Tags, Is.Not.Null);
             Assert.That(taggroup.Tags.Count, Is.GreaterThan(0));
@@ -116,12 +118,12 @@ namespace org.SharpTiles.Documentation.Test
         {
             var key = new ResourceKeyStack(bundle);
             key = key.BranchFor(new Core());
-            
-            var tag = new TagDocumentation(key, new Out(), new List<Func<ITag, TagDocumentation, bool>>());
+            var tagDict = new Dictionary<int,TagDocumentation>();
+            var tag = new TagDocumentation(key, new Out(), new List<Func<ITag, TagDocumentation, bool>>(),tagDict);
             Assert.That(tag.DescriptionKey, Is.EqualTo("description_Core_Out"));
         }
 
-       
+
         [Test]
         public void TestAllExpressionsHaveACategory()
         {
@@ -132,7 +134,7 @@ namespace org.SharpTiles.Documentation.Test
             }
         }
 
-        
+
 
         [Test]
         public void Json()
@@ -145,7 +147,7 @@ namespace org.SharpTiles.Documentation.Test
         }
 
 
-      
+
 
         private class TranslationChecker
         {
@@ -156,7 +158,7 @@ namespace org.SharpTiles.Documentation.Test
             {
                 _bundle = bundle;
             }
-            
+
             public void GuardDescription(string key)
             {
                 if (_bundle.Contains(key))
@@ -172,7 +174,7 @@ namespace org.SharpTiles.Documentation.Test
             }
         }
 
-        
+
     }
 
     public class TypeJsonConverter : JsonConverter

--- a/SharpTiles/org.SharpTiles.Documentation.Test/DocumentationGeneratorTest.cs
+++ b/SharpTiles/org.SharpTiles.Documentation.Test/DocumentationGeneratorTest.cs
@@ -2,27 +2,31 @@
  * SharpTiles, R.Z. Slijp(2008), www.sharptiles.org
  *
  * This file is part of SharpTiles.
- * 
+ *
  * SharpTiles is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SharpTiles is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with SharpTiles.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 using NUnit.Framework;
 using NUnit.Framework.SyntaxHelpers;
+using org.SharpTiles.Tags;
+using org.SharpTiles.Tags.CoreTags;
 
 namespace org.SharpTiles.Documentation.Test
 {
@@ -33,8 +37,47 @@ namespace org.SharpTiles.Documentation.Test
         public void HappyFlow()
         {
             var dg = new DocumentationGenerator();
-            var result=dg.GenerateDocumentation();
+            var result = dg.GenerateDocumentation();
             Assert.That(result, Is.Not.Null);
         }
+
+        [Test]
+        public void GenerateDocumentationForTagLib()
+        {
+            var lib = new TagLib();
+            lib.Register(new TestGroup());
+
+            //When
+            var model = new DocumentationGenerator().For(lib).BuildModel();
+            var result = JsonConvert.SerializeObject(model, Formatting.Indented);
+
+
+            // Then
+            File.WriteAllText("c:/Temp/TagLib.json", result);
+            Assert.That(result, Is.Not.Null);
+        }
+
+    }
+
+    public class TestGroup : BaseTagGroup<TestGroup>
+    {
+        public override string Name => "Test";
+
+        public TestGroup()
+        {
+            Register<TestSelfReferencingTag>();
+        }
+    }
+
+    public class TestSelfReferencingTag : BaseCoreTag, ITagExtendTagLib
+    {
+        public string TagName => "TestSelfReferencingTag";
+        public TagBodyMode TagBodyMode => TagBodyMode.FreeIgnoreUnkown;
+        public string Evaluate(TagModel model)
+        {
+            return string.Empty;
+        }
+
+        public ITagGroup TagLibExtension => new TestGroup();
     }
 }

--- a/SharpTiles/org.SharpTiles.Documentation.Test/TagDocumentationTest.cs
+++ b/SharpTiles/org.SharpTiles.Documentation.Test/TagDocumentationTest.cs
@@ -2,17 +2,17 @@
  * SharpTiles, R.Z. Slijp(2008), www.sharptiles.org
  *
  * This file is part of SharpTiles.
- * 
+ *
  * SharpTiles is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SharpTiles is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with SharpTiles.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -37,7 +37,8 @@ namespace org.SharpTiles.Documentation.Test
         [Test]
         public void InternalPropertyIsNotIncluded()
         {
-            var td = new TagDocumentation(new ResourceKeyStack(bundle), new Out(), new List<Func<ITag, TagDocumentation, bool>>());
+            var tagDict = new Dictionary<int,TagDocumentation>();
+            var td = new TagDocumentation(new ResourceKeyStack(bundle), new Out(), new List<Func<ITag, TagDocumentation, bool>>(), tagDict);
             bool hasBody = false;
             foreach (PropertyDocumentation property in td.Properties)
             {
@@ -49,7 +50,8 @@ namespace org.SharpTiles.Documentation.Test
         [Test]
         public void NonInternalPropertyIsIncluded()
         {
-            var td = new TagDocumentation(new ResourceKeyStack(bundle), new Out(), new List<Func<ITag, TagDocumentation, bool>>());
+            var tagDict = new Dictionary<int,TagDocumentation>();
+            var td = new TagDocumentation(new ResourceKeyStack(bundle), new Out(), new List<Func<ITag, TagDocumentation, bool>>(),tagDict);
             bool hasValue = false;
             foreach (PropertyDocumentation property in td.Properties)
             {
@@ -61,7 +63,8 @@ namespace org.SharpTiles.Documentation.Test
         [Test]
         public void IInstanceTagDocumentationPropertyIsUsed()
         {
-            var td = new TagDocumentation(new ResourceKeyStack(bundle), new InstanceTagDocumentationOut(), new List<Func<ITag, TagDocumentation, bool>>());
+            var tagDict = new Dictionary<int,TagDocumentation>();
+            var td = new TagDocumentation(new ResourceKeyStack(bundle), new InstanceTagDocumentationOut(), new List<Func<ITag, TagDocumentation, bool>>(), tagDict);
             bool hasBody = false;
             Assert.That(td.Description.Value, Is.EqualTo("Hi"));
          }
@@ -81,6 +84,6 @@ namespace org.SharpTiles.Documentation.Test
 //            Console.WriteLine(DocumentationAttributes.DescriptionAttribute.INNER_CONTENT.IsMatch(x));
 //            Console.WriteLine(DocumentationAttributes.DescriptionAttribute.INNER_CONTENT.Match(x).Groups[1].Value);
 //        }
-         
+
     }
 }

--- a/SharpTiles/org.SharpTiles.Documentation/DocumentModel.cs
+++ b/SharpTiles/org.SharpTiles.Documentation/DocumentModel.cs
@@ -2,17 +2,17 @@
  * SharpTiles, R.Z. Slijp(2008), www.sharptiles.org
  *
  * This file is part of SharpTiles.
- * 
+ *
  * SharpTiles is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SharpTiles is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with SharpTiles.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -32,7 +32,7 @@ namespace org.SharpTiles.Documentation
     [DataContract]
     public class DocumentModel
     {
-      
+
         private IList<ExpressionDocumentation> _expressions;
         private IList<FunctionDocumentation> _functions;
         private IList<FunctionDocumentation> _mathFunctions;
@@ -43,11 +43,12 @@ namespace org.SharpTiles.Documentation
         private bool _all;
         private IList<Func<ITag, TagDocumentation, bool>> _specials;
         private ExpressionLib _expressionlib;
+        private Dictionary<int, TagDocumentation> _tagDictionary;
 
         public DocumentModel(TagLib subject, bool all, ResourceBundle bundle, IList<Func<ITag, TagDocumentation, bool>> specials=null)
         {
             _expressionlib = new ExpressionLib();
-
+            _tagDictionary = new Dictionary<int, TagDocumentation>();
             _subject = subject;
             _all = all;
             _specials = specials??new List<Func<ITag, TagDocumentation, bool>>();
@@ -62,10 +63,10 @@ namespace org.SharpTiles.Documentation
         {
             _groups = new List<TagGroupDocumentation>();
             var lib = _subject;
-           
+
             foreach (ITagGroup tag in lib)
             {
-                _groups.Add(new TagGroupDocumentation(_resouceKey, tag, _specials));
+                _groups.Add(new TagGroupDocumentation(_resouceKey, tag, _specials, _tagDictionary));
             }
         }
 
@@ -151,5 +152,8 @@ namespace org.SharpTiles.Documentation
                 return list;
             }
         }
+
+        [DataMember]
+        public Dictionary<int, TagDocumentation> TagDictionary => _tagDictionary;
     }
 }

--- a/SharpTiles/org.SharpTiles.Documentation/DocumentationGenerator.cs
+++ b/SharpTiles/org.SharpTiles.Documentation/DocumentationGenerator.cs
@@ -2,31 +2,26 @@
  * SharpTiles, R.Z. Slijp(2008), www.sharptiles.org
  *
  * This file is part of SharpTiles.
- * 
+ *
  * SharpTiles is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SharpTiles is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with SharpTiles.  If not, see <http://www.gnu.org/licenses/>.
  */
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
-using org.SharpTiles.Common;
-using org.SharpTiles.Expressions.Functions;
-using org.SharpTiles.Expressions.Math;
 using org.SharpTiles.Tags;
 using org.SharpTiles.Tags.FormatTags;
 using org.SharpTiles.Tags.Templates.SharpTags;
-using org.SharpTiles.Templates;
 using org.SharpTiles.Templates.Templates;
 
 namespace org.SharpTiles.Documentation
@@ -69,7 +64,7 @@ namespace org.SharpTiles.Documentation
 
 //            var json = JsonConvert.SerializeObject(dm, new TypeJsonConverter(), new StringEnumConverter());
         }
-    
+
         public DocumentationGenerator AddSpecial(Func<ITag, TagDocumentation, bool> special)
         {
             _specials.Add(special);

--- a/SharpTiles/org.SharpTiles.TagLib/ITagLib.cs
+++ b/SharpTiles/org.SharpTiles.TagLib/ITagLib.cs
@@ -2,24 +2,21 @@
  * SharpTiles, R.Z. Slijp(2008), www.sharptiles.org
  *
  * This file is part of SharpTiles.
- * 
+ *
  * SharpTiles is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * SharpTiles is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with SharpTiles.  If not, see <http://www.gnu.org/licenses/>.
- */using System;
+ */
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using org.SharpTiles.Common;
 
 namespace org.SharpTiles.Tags


### PR DESCRIPTION
…to prevent circular references during generation